### PR TITLE
Bumps the maximum FOV up to 120 for parity with retail portal

### DIFF
--- a/game/client/hl2/clientmode_hlnormal.cpp
+++ b/game/client/hl2/clientmode_hlnormal.cpp
@@ -19,7 +19,7 @@
 
 extern bool g_bRollingCredits;
 
-ConVar fov_desired( "fov_desired", "75", FCVAR_ARCHIVE | FCVAR_USERINFO, "Sets the base field-of-view.", true, 75.0, true, 90.0 );
+ConVar fov_desired( "fov_desired", "75", FCVAR_ARCHIVE | FCVAR_USERINFO, "Sets the base field-of-view.", true, 75.0, true, 120.0 );
 
 //-----------------------------------------------------------------------------
 // Globals

--- a/game/client/portal/clientmode_portal.cpp
+++ b/game/client/portal/clientmode_portal.cpp
@@ -20,7 +20,7 @@
 
 // default FOV for HL2
 ConVar default_fov( "default_fov", "75", FCVAR_CHEAT );
-ConVar fov_desired( "fov_desired", "75", FCVAR_ARCHIVE | FCVAR_USERINFO, "Sets the base field-of-view.", true, 75.0, true, 90.0 );
+ConVar fov_desired( "fov_desired", "75", FCVAR_ARCHIVE | FCVAR_USERINFO, "Sets the base field-of-view.", true, 75.0, true, 120.0 );
 
 
 // The current client mode. Always ClientModeNormal in HL.

--- a/game/shared/gamerules.cpp
+++ b/game/shared/gamerules.cpp
@@ -944,7 +944,7 @@ void CGameRules::ClientSettingsChanged( CBasePlayer *pPlayer )
 	if ( pszFov )
 	{
 		int iFov = atoi(pszFov);
-		iFov = clamp( iFov, 75, 90 );
+		iFov = clamp( iFov, 75, 120 );
 		pPlayer->SetDefaultFOV( iFov );
 	}
 

--- a/game/shared/shareddefs.h
+++ b/game/shared/shareddefs.h
@@ -240,7 +240,7 @@ enum CastVote
 
 #define MAX_PLACE_NAME_LENGTH		18
 
-#define MAX_FOV						90
+#define MAX_FOV						120
 
 //===================================================================================================================
 // Team Defines


### PR DESCRIPTION
We thought we PR'd this earlier today, but apparently we didn't!

Further context behind this PR can be found in the Discord, but the tl;dr is that the codebase stems from a build prior to the steam deck qol update that, among other things, expanded the maximum FOV to 120 degrees, up from the previous maximum of 90. This does a pretty good job at alleviating motion sickness for folks like us who're more comfortable with higher FOV values!

A slightly comical alternative to this PR would be axing the maximum FOV entirely, but we figure it'd probably be wiser to go the route of parity instead